### PR TITLE
urwid 2.6.16 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/cwcwidth-feedstock/pr1/a71d524

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/cwcwidth-feedstock/pr1/a71d524

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<37]
-  # Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS
-  skip: True  # [win]
 
 requirements:
   build:
@@ -51,7 +49,7 @@ about:
   license: LGPL-2.1
   license_family: GPL
   license_file: COPYING
-  description: Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS
+  description: Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS and partially supports Windows OS
   doc_url: https://github.com/urwid/urwid
   dev_url: https://urwid.org
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,20 @@ requirements:
     - typing-extensions
     - wcwidth
 
+# E   ModuleNotFoundError: No module named '_curses'
+{% set deselect_tests_win = " --deselect=tests/test_columns.py::ColumnsTest::test_basic_sizing" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_columns.py::ColumnsTest::test_not_a_widget" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_columns.py::ColumnsTest::test_old_attributes" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_columns.py::ColumnsTest::test_pack_render_broken_sizing" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_event_loops.py::SelectEventLoopTest::test_remove_alarm" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_event_loops.py::SelectEventLoopTest::test_run" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_event_loops.py::SelectEventLoopTest::test_run_in_executor" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_grid_flow.py::GridFlowTest::test_not_fit" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_moved_imports.py::TestMovedImports::test_moved_imports_direct" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_padding.py::PaddingTest::test_insufficient_space" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_padding.py::PaddingTest::test_sizing" %}
+{% set deselect_tests_win = deselect_tests_win + " --deselect=tests/test_pile.py::PileTest::test_not_a_widget" %}
+
 test:
   source_files:
     - tests
@@ -38,7 +52,8 @@ test:
   commands:
     - pip check
     # CI is stuck and never ends on test_vterm.py.
-    - pytest -v tests --ignore=tests/test_vterm.py
+    - pytest -v tests --ignore=tests/test_vterm.py  # [unix]
+    - pytest -v tests {{ deselect_tests_win }} # [win]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,37 +1,59 @@
-{% set version = "2.1.2" %}
+{% set name = "urwid" %}
+{% set version = "2.6.16" %}
 
 package:
   name: urwid
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/u/urwid/urwid-{{ version }}.tar.gz
-  sha256: 588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 93ad239939e44c385e64aa00027878b9e5c486d59e855ec8ab5b1e1adcdb32a2
 
 build:
   number: 0
-  skip: true  # [win]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<37]
+  # Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS
+  skip: True  # [win]
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - python
     - pip
+    - wheel
+    - setuptools >=61.0.0
+    - setuptools-scm >=7.0
+    - toml
   run:
     - python
+    - typing-extensions
+    - wcwidth
 
 test:
+  source_files:
+    - tests
   imports:
     - urwid
-    - urwid.tests
+  commands:
+    - pip check
+    # CI is stuck and never ends on test_vterm.py.
+    - pytest -v tests --ignore=tests/test_vterm.py
+  requires:
+    - pip
+    - pytest
 
 about:
-  home: http://urwid.org/
-  license: LGPL-2.1
-  license_file: COPYING
+  home: https://urwid.org
   summary: A full-featured console (xterm et al.) user interface library
+  license: LGPL-2.1
+  license_family: GPL
+  license_file: COPYING
+  description: Urwid is a console user interface library for Python on Linux, OSX, Cygwin or other unix-like OS
+  doc_url: https://github.com/urwid/urwid
+  dev_url: https://urwid.org
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
urwid 2.6.16 

**Destination channel:** Defaults

### Links

- [PKG-9083]
- dev_url:        https://github.com/urwid/urwid/tree/2.6.16
- conda_forge:    https://github.com/conda-forge/urwid-feedstock
- pypi:           https://pypi.org/project/urwid/2.6.16
- pypi inspector: https://inspector.pypi.io/project/urwid/2.6.16

### Explanation of changes:

- new version number


[PKG-9083]: https://anaconda.atlassian.net/browse/PKG-9083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ